### PR TITLE
Nouveau readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-# Package-manager-azura
+# Azura
 
-Il faut savoir que le projet a été lancé pour palier à un besoin, celui d'un gestionnaire de paquet (pour la distribution NuTyX) simple au niveau du code à la fois pour les apprentis contributeur mais également pour les utilisateurs qui souhaitent comprendre leur système d'exploitation. Azura n'est qu'un test pour le moment et en dehors de l'équipe de dev, il n'a pas pour vocation de remplacer cards (l'actuel package manager de NuTyX), cependant le code est accessible à tous et tout le monde peut y contribuer. Si toutefois vous souhaitez l'utiliser, nous ne serons nullement responsable d'un plantage ou autre qui pourrait causer des problèmes irréversible sur votre os MERCI DE NE PAS L'UTILISER EN PRODUCTION :) . Concernant la contribution, sachez que Azura est ouvert à tous, si vous souhaitez contribuer, envoyez moi un message privé sur la messagerie telegram. Notre principal objectif est de créer un code simple compréhensible par notre communauté.
-De plus, il contient un script qui permet après une installation BASE d'installer tout le nécessaire dont vous pouvez avoir besoin.
+Azura est un package manager conçu pour la distribution GNU/Linux [NuTyx](https://nutyx.org) ayant pour vocation d'avoir un code simple à comprendre (écrit en Python), ce dans le but de simplifier les contribution ou de permettre a chacun de comprendre le fonctionnement de son géstionnaire de packet si il le désire. 
 
-# Me contacter
+### Avertissement
 
-Vous pouvez le faire sur telegram via mon groupe : https://t.me/joinchat/Sd0m11kiWnuIqk7l ou bien en pv ;)
+Azura est encore à un stade de prototypage, son utilisation est donc *fortement déconséillée*. De plus, Azura *n'as pas* pour vocation de remplacer [cards](https://github.com/NuTyX/cards). 
 
-# A propos de ce dépôt
-Il contient les dernières release stables de Azura. Si vous voulez retrouver la version minimale en SHELL (pour ceux qui ont connus cette version), elle est disponible sur le dépôt community. Enfin, si vous souhaitez obtenir les dernières nouveautées du code, nous vous invitons à consulter le dépôt : Azura-build-community.
+
+## Contribution :
+
+Azura étant libre et open source, contribuer à son développement peut se faire *via* une [pull request](https://github.com/Delta-Azura/Package-manager-azura/pulls). Si vous souhaitez rejoindre l'équipe, contactez [Delta](https://github.com/Delta-Azura) sur [télégram](https://telegram.org) (@Delta ou *via* [son groupe sur ce même réseau](https://t.me/joinchat/Sd0m11kiWnuIqk7l))
+
+
+## Actuellement :
+
+Pour l'instant, Azura propose un script qui permet après une installation BASE d'installer tout le nécessaire dont vous pouvez avoir besoin.
 
 # Remerciements 
 


### PR DESCRIPTION
Proposition de readme, plus organisé.
la rétraction de la section "a propos de ce dépot" est du au fait que dans un cadre idéal, l'autre repo n'aurait plus lieu d'être :
- Les versions stables se retrouveraient dans les "releases" du dépot
- Les essais et prototype sucéptible de poser problèmes passeraient par une branche parallèle du dépot et incorporer via une pr